### PR TITLE
Add support for tracking referenced graph ID in MongoDB history  

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -501,8 +501,11 @@ class AiAssistance:
                     query=query,
                     user_id=user_id,
                     context=None,
+                    graph_id_referenced=graph_id,
                 )
-                self.history.create_history(user_id, query, final_response)
+                self.history.create_history(
+                    user_id, query, final_response, graph_id_referenced=graph_id
+                )
                 emit_to_user(user=user_id, message=final_response, status="completed")
                 return {"text": final_response}
 
@@ -539,12 +542,18 @@ class AiAssistance:
                     if isinstance(agent_response, dict)
                     else str(agent_response)
                 )
-                self.history.create_history(user_id, query, assistant_answer)
+                self.history.create_history(
+                    user_id, query, assistant_answer, graph_id_referenced=graph_id
+                )
                 return agent_response
         else:
             logger.error("No response generated from LLM")
             await self.store.save_user_information(
-                self.advanced_llm, query, user_id, resource
+                self.advanced_llm,
+                query,
+                user_id,
+                resource,
+                graph_id_referenced=graph_id,
             )
             emit_to_user(
                 user=user_id,
@@ -584,7 +593,9 @@ class AiAssistance:
                 logger.info("question is related with the graph")
                 query_response = response[len("related:") :].strip()
                 # creating users history
-                self.history.create_history(user_id, query, query_response)
+                self.history.create_history(
+                    user_id, query, query_response, graph_id_referenced=graph_id
+                )
                 logger.info(f"user query is {query} response is {query_response}")
                 return {"text": query_response}
             elif "not" in response:

--- a/app/storage/history_manager.py
+++ b/app/storage/history_manager.py
@@ -4,7 +4,9 @@ import uuid
 
 
 class HistoryManager:
-    def create_history(self, user_id, user_message, assistant_answer):
+    def create_history(
+        self, user_id, user_message, assistant_answer, graph_id_referenced=None
+    ):
         # Generate a unique query_id
         query_id = str(uuid.uuid4())
 
@@ -14,6 +16,7 @@ class HistoryManager:
             user_question=user_message,
             memory=None,
             context=None,
+            graph_id_referenced=graph_id_referenced,
         )
 
         # Update the assistant_answer and question_id for the latest record
@@ -45,6 +48,7 @@ class HistoryManager:
                     "query_id": record.get("question_id"),
                     "user": record.get("user_question"),
                     "assistant answer": record.get("assistant_answer"),
+                    "graph_id_referenced": record.get("graph_id_referenced"),
                     "time": (
                         record.get("time").isoformat() if record.get("time") else None
                     ),
@@ -62,6 +66,7 @@ class HistoryManager:
                 "query_id": record.get("question_id"),
                 "user": record.get("user_question"),
                 "assistant answer": record.get("assistant_answer"),
+                "graph_id_referenced": record.get("graph_id_referenced"),
                 "time": record.get("time").isoformat() if record.get("time") else None,
             }
         return None

--- a/app/storage/mongo_storage.py
+++ b/app/storage/mongo_storage.py
@@ -58,6 +58,7 @@ class MongoManager:
         user_question: str,
         memory: dict = None,
         context: dict = None,
+        graph_id_referenced: str = None,
     ):
         try:
             # Clean old records (keep only 3 most recent)
@@ -69,6 +70,7 @@ class MongoManager:
                 "user_question": user_question,
                 "memory": json.dumps(memory) if memory else None,
                 "context": json.dumps(context) if context else None,
+                "graph_id_referenced": graph_id_referenced,
                 "time": datetime.utcnow(),
                 "assistant_answer": None,
                 "created_at": datetime.utcnow(),
@@ -323,10 +325,16 @@ class MongoManager:
             logger.error(f"Error getting context and memory: {e}")
             return []
 
-    async def save_user_information(self, advanced_llm, query, user_id, context=None):
+    async def save_user_information(
+        self, advanced_llm, query, user_id, context=None, graph_id_referenced=None
+    ):
         try:
             user_info = self.create_user_information(
-                user_id=user_id, user_question=query, memory="", context=context
+                user_id=user_id,
+                user_question=query,
+                memory="",
+                context=context,
+                graph_id_referenced=graph_id_referenced,
             )
             logger.info(
                 f"Saved user information with question_id: {user_info['question_id']}"


### PR DESCRIPTION
### Overview  
This PR adds support for tracking which graph ID was referenced when users make queries through the `/query` endpoint. The `graph_id_referenced` field is now stored in MongoDB to maintain a complete audit trail of user interactions with specific biological graphs.  

### Changes Made  

#### Files Modified:  
- **`app/storage/history_manager.py`**: Updated `create_history()` method to accept and store `graph_id_referenced` parameter  
- **`app/storage/mongo_storage.py`**: Added `graph_id_referenced` field to user information records  
- **`app/main.py`**: Updated all history creation and user information storage calls to pass the graph_id  