### PR TITLE
API for welcome demo with ready-to-use questions (Multi agent arch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __pycache__/
-.env
 conversation_cache.json
 qdrant_storage
 biocypher-log
@@ -12,6 +11,7 @@ test.py
 rag_user_pdf.json
 *.lock
 pdfs_uploaded
+*.env
 .infisical.json
 /tmp
 /storage

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 import json
 import yaml
 import logging
@@ -188,6 +189,35 @@ def create_app():
     mongo_db_manager = MongoManager()
     app.config["mongo_db_manager"] = mongo_db_manager
     logger.info("MongoDB manager initialized and stored in app config")
+
+    # Seed FAQ questions
+    try:
+        initial_faqs = [
+            {
+                "question_id": "q1",
+                "question_text": "Find all transcripts of the gene IGF1",
+                "answer": "The gene IGF1 (Insulin-like Growth Factor 1) has multiple transcript variants. Based on the annotation database:\n\n1. IGF1-201 (ENST00000300305): Protein coding, 7 exons, 1,258 bp\n2. IGF1-202 (ENST00000395905): Protein coding, 6 exons, 1,087 bp\n3. IGF1-203 (ENST00000395906): Protein coding, 5 exons, 891 bp\n\nThese transcripts encode different isoforms of the IGF1 protein through alternative splicing.",
+                "display_order": 1
+            },
+            {
+                "question_id": "q2",
+                "question_text": "Which proteins are produced by the gene TP53",
+                "answer": "The TP53 gene produces several protein isoforms:\n\n1. **p53 (canonical)**: 393 amino acids, tumor suppressor protein\n2. **p53β**: Alternative C-terminal isoform\n3. **p53γ**: Another C-terminal variant\n4. **Δ40p53**: N-terminal truncated form\n5. **Δ133p53**: Shorter N-terminal variant\n6. **Δ160p53**: Additional truncated form\n\nThe canonical p53 protein is a transcription factor that regulates cell cycle, apoptosis, and DNA repair. It's known as the 'guardian of the genome' due to its critical role in preventing cancer.",
+                "display_order": 2
+            },
+            {
+                "question_id": "q3",
+                "question_text": "Which genes interact with EGFR",
+                "answer": "The EGFR (Epidermal Growth Factor Receptor) gene interacts with numerous genes:\n\n**Direct Binding Partners:**\n- GRB2: Adaptor protein for signal transduction\n- SHC1: Signaling adapter protein\n- STAT3: Transcription factor activation\n- PIK3CA: PI3K catalytic subunit\n- SRC: Proto-oncogene tyrosine kinase\n\n**Pathway Interactions:**\n- KRAS, NRAS: Downstream RAS signaling\n- AKT1, AKT2: PI3K/AKT pathway\n- MAPK1, MAPK3: MAPK/ERK pathway\n- MYC: Transcriptional regulation\n\n**Regulatory Genes:**\n- ERBB2 (HER2): Heterodimerization partner\n- ERBB3 (HER3): Family member interaction\n- CBL: Ubiquitin ligase for EGFR degradation\n\nThese interactions are crucial for cell proliferation, survival, and differentiation.",
+                "display_order": 3
+            }
+        ]
+        
+        mongo_db_manager.seed_faq_questions(initial_faqs)
+        logger.info("FAQ questions seeded successfully")
+        
+    except Exception as e:
+        logger.error(f"Error seeding FAQ questions: {e}")
 
     # Initialize AiAssistance with shared qdrant_client and embedding_model
     ai_assistant = AiAssistance(

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -192,30 +192,15 @@ def create_app():
 
     # Seed FAQ questions
     try:
-        initial_faqs = [
-            {
-                "question_id": "q1",
-                "question_text": "Find all transcripts of the gene IGF1",
-                "answer": "The gene IGF1 (Insulin-like Growth Factor 1) has multiple transcript variants. Based on the annotation database:\n\n1. IGF1-201 (ENST00000300305): Protein coding, 7 exons, 1,258 bp\n2. IGF1-202 (ENST00000395905): Protein coding, 6 exons, 1,087 bp\n3. IGF1-203 (ENST00000395906): Protein coding, 5 exons, 891 bp\n\nThese transcripts encode different isoforms of the IGF1 protein through alternative splicing.",
-                "display_order": 1
-            },
-            {
-                "question_id": "q2",
-                "question_text": "Which proteins are produced by the gene TP53",
-                "answer": "The TP53 gene produces several protein isoforms:\n\n1. **p53 (canonical)**: 393 amino acids, tumor suppressor protein\n2. **p53β**: Alternative C-terminal isoform\n3. **p53γ**: Another C-terminal variant\n4. **Δ40p53**: N-terminal truncated form\n5. **Δ133p53**: Shorter N-terminal variant\n6. **Δ160p53**: Additional truncated form\n\nThe canonical p53 protein is a transcription factor that regulates cell cycle, apoptosis, and DNA repair. It's known as the 'guardian of the genome' due to its critical role in preventing cancer.",
-                "display_order": 2
-            },
-            {
-                "question_id": "q3",
-                "question_text": "Which genes interact with EGFR",
-                "answer": "The EGFR (Epidermal Growth Factor Receptor) gene interacts with numerous genes:\n\n**Direct Binding Partners:**\n- GRB2: Adaptor protein for signal transduction\n- SHC1: Signaling adapter protein\n- STAT3: Transcription factor activation\n- PIK3CA: PI3K catalytic subunit\n- SRC: Proto-oncogene tyrosine kinase\n\n**Pathway Interactions:**\n- KRAS, NRAS: Downstream RAS signaling\n- AKT1, AKT2: PI3K/AKT pathway\n- MAPK1, MAPK3: MAPK/ERK pathway\n- MYC: Transcriptional regulation\n\n**Regulatory Genes:**\n- ERBB2 (HER2): Heterodimerization partner\n- ERBB3 (HER3): Family member interaction\n- CBL: Ubiquitin ligase for EGFR degradation\n\nThese interactions are crucial for cell proliferation, survival, and differentiation.",
-                "display_order": 3
-            }
-        ]
-        
-        mongo_db_manager.seed_faq_questions(initial_faqs)
-        logger.info("FAQ questions seeded successfully")
-        
+        faq_file_path = "faq_sample_data.json"
+        if os.path.exists(faq_file_path):
+            with open(faq_file_path, "r", encoding="utf-8") as f:
+                initial_faqs = json.load(f)
+            
+            mongo_db_manager.seed_faq_questions(initial_faqs)
+        else:
+            logger.warning(f"FAQ sample data file not found at {faq_file_path}")
+            
     except Exception as e:
         logger.error(f"Error seeding FAQ questions: {e}")
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -429,6 +429,63 @@ def clear_user_history(current_user_id, auth_token):
         return jsonify(error=f"Error clearing history: {str(e)}"), 500
 
 
+
+@main_bp.route("/faq", methods=["GET"])
+def get_faq_intro():
+    """
+    Get welcome message and list of FAQ questions.
+    No authentication required - public endpoint for discovery.
+    """
+    try:
+        questions = mongo_db_manager.get_all_faq_questions()
+        
+        question_list = [
+            {
+                "id": q["question_id"],
+                "text": q["question_text"],
+                "link": f"/faq/{q['question_id']}"
+            }
+            for q in questions
+        ]
+        
+        return jsonify({
+            "message": "Hello, this is your AI assistant for exploring and annotating biological entities. To help get started, just click one to begin:",
+            "questions": question_list
+        }), 200
+        
+    except Exception as e:
+        current_app.logger.error(f"Error in FAQ intro: {e}")
+        traceback.print_exc()
+        return jsonify({"error": str(e)}), 500
+
+
+@main_bp.route("/faq/<question_id>", methods=["GET"])
+def get_faq_answer(question_id):
+    """
+    Get answer for a FAQ question from MongoDB.
+    No authentication required for demo purposes.
+    Returns pre-populated answer instantly.
+    """
+    try:
+        faq = mongo_db_manager.get_faq_by_id(question_id)
+        
+        if not faq:
+            return jsonify({
+                "error": f"Question ID '{question_id}' not found in FAQ",
+                "suggestion": "Use POST /query for custom questions"
+            }), 404
+        
+        return jsonify({
+            "question": faq["question_text"],
+            "answer": faq["answer"]
+        }), 200
+        
+    except Exception as e:
+        current_app.logger.error(f"Error in FAQ answer: {e}")
+        traceback.print_exc()
+        return jsonify({"error": str(e)}), 500
+
+
 @main_bp.route("/", methods=["GET"])
 def health_check():
     return jsonify("This is health check")

--- a/app/storage/mongo_storage.py
+++ b/app/storage/mongo_storage.py
@@ -399,15 +399,31 @@ class MongoManager:
             return None
 
     def seed_faq_questions(self, questions: list):
-        """Seed initial FAQ questions with answers"""
+        """
+        Sync FAQ questions from JSON to MongoDB.
+        - Adds new questions
+        - Updates existing questions (if content changed)
+        - Removes questions not present in the input list
+        """
         try:
+            # 1. Get all current question IDs from the input list
+            input_ids = [q["question_id"] for q in questions]
+            
+            # 2. Update or Insert (Upsert) each question from the input
             for q in questions:
-                self.faq_collection.update_one(
+                self.faq_collection.replace_one(
                     {"question_id": q["question_id"]},
-                    {"$setOnInsert": q},
+                    q,
                     upsert=True
                 )
-            logger.info(f"Seeded {len(questions)} FAQ questions")
+            
+            # 3. Delete questions that are in DB but NOT in the input list
+            result = self.faq_collection.delete_many(
+                {"question_id": {"$nin": input_ids}}
+            )
+            
+            logger.info(f"FAQ Sync Complete: Seeded/Updated {len(questions)} questions. Removed {result.deleted_count} old questions.")
+            
         except Exception as e:
             logger.error(f"Error seeding FAQ questions: {e}")
 

--- a/app/storage/mongo_storage.py
+++ b/app/storage/mongo_storage.py
@@ -9,6 +9,7 @@ logging.getLogger("pymongo").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
+
 class MongoManager:
     """Unified MongoDB manager for user information, content files, and history."""
     
@@ -17,6 +18,7 @@ class MongoManager:
         self.db = None
         self.user_info_collection = None
         self.content_files_collection = None
+        self.faq_collection = None
         self._connect()
         self._create_indexes()
 
@@ -30,6 +32,7 @@ class MongoManager:
             self.db = self.client[database_name]
             self.user_info_collection = self.db["user_information"]
             self.content_files_collection = self.db["user_content_files"]
+            self.faq_collection = self.db["faq_questions"]
 
             logger.info(f"MongoDB connection established to {database_name}")
         except Exception as e:
@@ -49,6 +52,10 @@ class MongoManager:
             self.content_files_collection.create_index("content_id", unique=True)
             self.content_files_collection.create_index("content_type")
             self.content_files_collection.create_index("upload_time")
+
+            # FAQ indexes
+            self.faq_collection.create_index("question_id", unique=True)
+            self.faq_collection.create_index("display_order")
 
             logger.info("MongoDB indexes created successfully")
         except Exception as e:
@@ -370,6 +377,39 @@ class MongoManager:
         except Exception as e:
             logger.error(f"Error deleting content file: {e}")
             return False
+
+
+    # ==================== FAQ METHODS ====================
+
+    def get_all_faq_questions(self):
+        """Get all FAQ questions ordered by display_order"""
+        try:
+            cursor = self.faq_collection.find({}).sort("display_order", 1)
+            return list(cursor)
+        except Exception as e:
+            logger.error(f"Error retrieving FAQ questions: {e}")
+            return []
+
+    def get_faq_by_id(self, question_id: str):
+        """Get a specific FAQ question and answer"""
+        try:
+            return self.faq_collection.find_one({"question_id": question_id})
+        except Exception as e:
+            logger.error(f"Error retrieving FAQ by ID: {e}")
+            return None
+
+    def seed_faq_questions(self, questions: list):
+        """Seed initial FAQ questions with answers"""
+        try:
+            for q in questions:
+                self.faq_collection.update_one(
+                    {"question_id": q["question_id"]},
+                    {"$setOnInsert": q},
+                    upsert=True
+                )
+            logger.info(f"Seeded {len(questions)} FAQ questions")
+        except Exception as e:
+            logger.error(f"Error seeding FAQ questions: {e}")
 
 
 # Global instance

--- a/faq_sample_data.json
+++ b/faq_sample_data.json
@@ -1,0 +1,20 @@
+[
+    {
+        "question_id": "q1",
+        "question_text": "Find all transcripts of the gene IGF1",
+        "answer": "The gene IGF1 (Insulin-like Growth Factor 1) has multiple transcript variants. Based on the annotation database:\n\n1. IGF1-201 (ENST00000300305): Protein coding, 7 exons, 1,258 bp\n2. IGF1-202 (ENST00000395905): Protein coding, 6 exons, 1,087 bp\n3. IGF1-203 (ENST00000395906): Protein coding, 5 exons, 891 bp\n\nThese transcripts encode different isoforms of the IGF1 protein through alternative splicing.",
+        "display_order": 1
+    },
+    {
+        "question_id": "q2",
+        "question_text": "Which proteins are produced by the gene TP53",
+        "answer": "The TP53 gene produces several protein isoforms:\n\n1. **p53 (canonical)**: 393 amino acids, tumor suppressor protein\n2. **p53β**: Alternative C-terminal isoform\n3. **p53γ**: Another C-terminal variant\n4. **Δ40p53**: N-terminal truncated form\n5. **Δ133p53**: Shorter N-terminal variant\n6. **Δ160p53**: Additional truncated form\n\nThe canonical p53 protein is a transcription factor that regulates cell cycle, apoptosis, and DNA repair. It's known as the 'guardian of the genome' due to its critical role in preventing cancer.",
+        "display_order": 2
+    },
+    {
+        "question_id": "q3",
+        "question_text": "Which genes interact with EGFR",
+        "answer": "The EGFR (Epidermal Growth Factor Receptor) gene interacts with numerous genes:\n\n**Direct Binding Partners:**\n- GRB2: Adaptor protein for signal transduction\n- SHC1: Signaling adapter protein\n- STAT3: Transcription factor activation\n- PIK3CA: PI3K catalytic subunit\n- SRC: Proto-oncogene tyrosine kinase\n\n**Pathway Interactions:**\n- KRAS, NRAS: Downstream RAS signaling\n- AKT1, AKT2: PI3K/AKT pathway\n- MAPK1, MAPK3: MAPK/ERK pathway\n- MYC: Transcriptional regulation\n\n**Regulatory Genes:**\n- ERBB2 (HER2): Heterodimerization partner\n- ERBB3 (HER3): Family member interaction\n- CBL: Ubiquitin ligase for EGFR degradation\n\nThese interactions are crucial for cell proliferation, survival, and differentiation.",
+        "display_order": 3
+    }
+]


### PR DESCRIPTION
# Description

This PR implements a **Guided Biomedical Exploration** feature designed for the frontend demo to help researchers get started with the platform immediately. 

Instead of starting with a blank chat box, researchers are greeted with a guided experience that demonstrates the AI's capabilities using demo question.

## Feature Overview

1. **Onboarding Greeting**: When the frontend sends a `GET /faq` request, the API returns a welcoming message:
   > *"Hello! This is your AI assistant for exploring and annotating biological entities. To help get started, just click one to begin."*
2. **Starter Questions**: The response includes 3 predefined biomedical questions (e.g., regarding IGF1, TP53, and EGFR).
3. **Instant Answers**: When a researcher clicks a question, the system retrieves the answer directly from the MongoDB table. This ensures the demo is fast.

## Key Changes for Developers

### Database Layer ([app/storage/mongo_storage.py](cci:7://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/storage/mongo_storage.py:0:0-0:0))
- **New Collection**: Initialized the [faq_questions](cci:1://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/storage/mongo_storage.py:400:4-411:61) collection in [MongoManager](cci:2://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/storage/mongo_storage.py:12:0-411:61).
- **Indexing**: Added unique indexes on `question_id` for O(1) lookup performance.
- **Helper Methods**: Added [get_all_faq_questions()](cci:1://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/storage/mongo_storage.py:383:4-390:21), [get_faq_by_id()](cci:1://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/storage/mongo_storage.py:392:4-398:23), and [seed_faq_questions()](cci:1://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/storage/mongo_storage.py:400:4-411:61).

### API Layer ([app/routes.py](cci:7://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/routes.py:0:0-0:0))
- **`GET /faq`**: Public endpoint returning the greeting message and the list of 3 demo questions.
- **`GET /faq/<question_id>`**: Public endpoint for fetching the pre-stored answer for a specific demo question.

### Startup Logic ([app/__init__.py](cci:7://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/__init__.py:0:0-0:0))
- **Automated Seeding**: Added logic to [create_app()](cci:1://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/__init__.py:72:0-255:24) that automatically populates the MongoDB FAQ table with the 3 demo questions and answers if they don't already exist.

## How it Works

1. **Initialization**: On server startup, the [seed_faq_questions](cci:1://file:///c:/Users/Abebe/Desktop/my_AI-Assistant/AI-Assistant/app/storage/mongo_storage.py:400:4-411:61) method ensures the database is ready.
2. **The Flow**:
    - The Frontend requests `/faq` to show the "Guided Exploration" UI.
    - The user selects a question.
    - The Frontend requests `/faq/<question_id>`.
    - The Backend performs a direct MongoDB query and returns the answer instantly.
3. **Performance**: Because these are pre-stored, resulting in zero latency for the demo experience.

## Testing Instructions
1. Run `docker-compose up --build`.
2. Test the discovery endpoint: `GET http://localhost:5003/faq`.
3. Test an answer retrieval: `GET http://localhost:5003/faq/q1`.