### PR TITLE
Fix Trivy SARIF upload permissions and update CodeQL action

### DIFF
--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -216,6 +216,9 @@ jobs:
       (github.event_name == 'pull_request') ||
       (github.event_name == 'push')
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     outputs:
       validation-status: ${{ steps.validate-container.outcome }}
@@ -528,7 +531,8 @@ jobs:
 
     - name: Upload Trivy results to GitHub Security
       if: always() && steps.validate-container.outcome == 'success'
-      uses: github/codeql-action/upload-sarif@v3
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
Fix Trivy SARIF upload permissions and update CodeQL action

- Add security-events: write and contents: read permissions to build-and-validate-assistant job
- Add continue-on-error: true to upload-sarif step so scan failures don't block the pipeline
- Bump github/codeql-action/upload-sarif from v3 to v4 (v3 deprecated Dec 2026)
